### PR TITLE
Implement routes and actions for favorite apps

### DIFF
--- a/app/contexts/fav_app_context.rb
+++ b/app/contexts/fav_app_context.rb
@@ -1,0 +1,52 @@
+# This class is responsible for fetching and organizing
+# data about apps in a coherent Hash that can be sent to the frontend
+SELECT = "apps.*, user_favorite_apps.user_id as follower_id, user_favorite_apps.app_id as favapp_id"
+FavoriteJoin = -> (params) { "LEFT OUTER JOIN \"user_favorite_apps\" ON \"user_favorite_apps\".\"app_id\" = \"apps\".\"id\" AND " + 
+                    "\"user_favorite_apps\".\"user_id\" = #{params[:current_user]["id"]}" }
+
+class FavAppContext
+    # Simple function that fetches all apps, and if the current user is logged in, attaches a 'is_favorite'
+    # tag to the hash
+    def self.all (params = {})
+        if params[:current_user]
+            apps = App.joins(FavoriteJoin.call(params)).select(SELECT)
+            self.to_hashes(apps)
+        else
+            apps = App.all
+            self.to_hashes(apps)
+        end
+    end
+
+    def self.find_by (params = {}) 
+        if params[:current_user]
+            app = App.joins(FavoriteJoin.call(params)).select(SELECT).find_by(params.except(:current_user))
+            self.to_hash(app)
+        else
+            app = App.find_by(params.except(:current_user))
+            self.to_hash(app)
+        end
+    end
+
+    def self.where (params = {})
+        if params[:current_user]
+            apps = App.joins(FavoriteJoin.call(params)).select(SELECT).where(params.except(:current_user))
+            self.to_hashes(apps)
+        else 
+            apps = App.where(params.except(:current_user))
+            self.to_hashes(apps)
+        end
+    end
+
+
+    def self.to_hashes (apps)
+        apps.map { |app| 
+            self.to_hash(app)
+        }
+    end
+
+    def self.to_hash(app)
+        hash = app.attributes
+        hash["is_favorite"] = hash["follower_id"] != nil
+        hash
+    end
+end

--- a/app/controllers/apps_controller.rb
+++ b/app/controllers/apps_controller.rb
@@ -4,25 +4,28 @@ class AppsController < ApplicationController
 
   # GET /apps
   def index
-    @apps = App.all
+    @apps = FavAppContext.all(current_user: current_user)
     json_response(@apps)
   end
 
   # GET /app/:id
   def show
-    json_response(@app)
+    app = FavAppContext.find_by(current_user: current_user, id: @app)
+    json_response(app)
   end
 
   # POST /apps
   def create
     @app = App.create(app_params)
-    json_response(@app, :created)
+    app = FavAppContext.find_by(current_user: current_user, id: @app)
+    json_response(app, :created)
   end
 
   # PUT /apps/:id
   def update
     @app.update!(app_params)
-    json_response(@app)
+    app = FavAppContext.find_by(current_user: current_user, id: @app)
+    json_response(app)
   end
 
   # DELETE /apps/:id

--- a/app/controllers/me/favorite_apps_controller.rb
+++ b/app/controllers/me/favorite_apps_controller.rb
@@ -1,0 +1,58 @@
+class Me::FavoriteAppsController < ApplicationController
+    before_action :authenticate_user!
+    before_action :set_user
+
+    # GET me/favorite_apps
+    def index 
+        if @user 
+            apps = current_user.favorite_apps
+            json_response(apps)
+        else
+            head :forbidden
+        end
+    end
+
+    # PUT me/favorite_apps/:id
+    def update
+        @app = App.find(fav_params[:id])
+
+        if !@app 
+            head :not_found
+        else
+            if @user
+                if UserFavoriteApp.where(follower: @user, favorite_app: @app).length == 0
+                    @user.favorite_apps = @user.favorite_apps + [@app]
+                end
+                head :no_content
+            else
+                head :forbidden
+            end
+        end
+
+    end
+
+    # DELETE me/favorite_apps/:id
+    def destroy
+        @app = App.find(fav_params[:id])
+
+        if !@app
+            head :not_found
+        else 
+            if @user
+                UserFavoriteApp.destroy_by(follower: @user, favorite_app: @app)
+            end
+            head :no_content
+        end
+
+    end
+
+
+    def set_user 
+        @user = current_user
+    end
+
+    def fav_params
+        params.permit(:id)
+    end
+
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
   # CRUD for resources owned by the authenticated user
   namespace :me do 
     resources :apps, except: [:new, :edit]
+    resources :favorite_apps, only: [:index, :update, :destroy]
   end
 
   get 'users/:id/portfolio', to: 'users#portfolio'


### PR DESCRIPTION
This PR implements the following routes at the root `me/favorite_apps`

- `GET /` returns all of a user's favorite apps
- `PUT /:app_id`, with no body, will add the app to the user's favorite apps
- `DELETE /:app_id`, with no body, will delete the specified app from the user's favorite apps.

This PR also transforms the data returned from the `/apps` endpoints so that if the user is logged out, the `is_favorite = false` parameter is on the response, and if the user is logged in, the `is_favorite` parameter will be set to `true` if the app is one of the user's favorite apps.