### PR TITLE
Comments should cascade delete on app deletion

### DIFF
--- a/db/migrate/20200529214330_foreign_keys.rb
+++ b/db/migrate/20200529214330_foreign_keys.rb
@@ -1,0 +1,6 @@
+class ForeignKeys < ActiveRecord::Migration[6.0]
+  def change
+      remove_foreign_key :comments, :apps
+      add_foreign_key :comments, :apps, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_27_200841) do
+ActiveRecord::Schema.define(version: 2020_05_29_214330) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -104,6 +104,6 @@ ActiveRecord::Schema.define(version: 2020_05_27_200841) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "apps", "categories", on_delete: :nullify
   add_foreign_key "apps", "users", on_delete: :cascade
-  add_foreign_key "comments", "apps"
+  add_foreign_key "comments", "apps", on_delete: :cascade
   add_foreign_key "tags", "apps", on_delete: :cascade
 end


### PR DESCRIPTION
Adds the on_delete CASCADE constraint to comments, so that apps can be deleting successfully.